### PR TITLE
Highlight planting on calendar

### DIFF
--- a/style.less
+++ b/style.less
@@ -861,6 +861,9 @@ header{
 				}
 			}
 			
+			.planting, .planting + more {
+				background: #d0ae96;
+			}
 			.planting, .harvesting{
 				padding-bottom: 11px;
 				.clearfix;

--- a/style.less
+++ b/style.less
@@ -864,6 +864,11 @@ header{
 			.planting, .planting + more {
 				background: #d0ae96;
 			}
+			&:nth-child(7n+3) {
+				.planting, .planting + more {
+					background: #cc978d;
+				}
+			}
 			.planting, .harvesting{
 				padding-bottom: 11px;
 				.clearfix;


### PR DESCRIPTION
It was confusing that planting was vertically aligned with harvesting on a day with no planting, so I tweaked the CSS to highlight planting expenditures.